### PR TITLE
Extend PickerView to fit width of the main view

### DIFF
--- a/MMPickerView/MMPickerView.m
+++ b/MMPickerView/MMPickerView.m
@@ -180,7 +180,7 @@ NSString * const MMshowsSelectionIndicator = @"showsSelectionIndicator";
   [self addSubview:_pickerViewContainerView];
   
   //PickerView Container with top bar
-  _pickerContainerView = [[UIView alloc] initWithFrame:CGRectMake(0.0, _pickerViewContainerView.bounds.size.height - 260.0, 320.0, 260.0)];
+  _pickerContainerView = [[UIView alloc] initWithFrame:CGRectMake(0.0, _pickerViewContainerView.bounds.size.height - 260.0, view.bounds.size.width, 260.0)];
     
   //Default Color Values (if colors == nil)
   
@@ -273,7 +273,7 @@ NSString * const MMshowsSelectionIndicator = @"showsSelectionIndicator";
   */
   
   //Add pickerView
-  _pickerView = [[UIPickerView alloc] initWithFrame:CGRectMake(0.0, 44.0, 320.0, 216.0)];
+  _pickerView = [[UIPickerView alloc] initWithFrame:CGRectMake(0.0, 44.0, view.bounds.size.width, 216.0)];
   [_pickerView setDelegate:self];
   [_pickerView setDataSource:self];
   [_pickerView setShowsSelectionIndicator: _pickerViewShowsSelectionIndicator];//YES];


### PR DESCRIPTION
PickerView should take the complete width of the view to look good.
For example on iPad landscape mode PickerView is too small.
