### PR TITLE
Don't show the picker if it's already showing.

### DIFF
--- a/MMPickerView/MMPickerView.m
+++ b/MMPickerView/MMPickerView.m
@@ -61,6 +61,11 @@ NSString * const MMshowsSelectionIndicator = @"showsSelectionIndicator";
                 withOptions:(NSDictionary *)options
                  completion:(void (^)(NSString *))completion{
   
+  if ([[view subviews] containsObject:[self sharedView]]) {
+    // The picker is already showing.
+    return;
+  }
+  
   [[self sharedView] initializePickerViewInView:view
                                       withArray:strings
                                     withOptions:options];
@@ -76,6 +81,11 @@ NSString * const MMshowsSelectionIndicator = @"showsSelectionIndicator";
                 withOptions:(NSDictionary *)options
     objectToStringConverter:(NSString *(^)(id))converter
                  completion:(void (^)(id))completion {
+  
+  if ([[view subviews] containsObject:[self sharedView]]) {
+    // The picker is already showing.
+    return;
+  }
   
   [self sharedView].objectToStringConverter = converter;
   [self sharedView].onDismissCompletion = completion;


### PR DESCRIPTION
If the picker is already displayed, and a user taps a control to show it again (e.g., in a space that isn't covered by the overlay like a `UINavigationBar`), the picker and associated views will be added again. This code avoids that.
