### PR TITLE
Replaced constant which return current ios version

### DIFF
--- a/MMPickerView/MMPickerView.m
+++ b/MMPickerView/MMPickerView.m
@@ -248,7 +248,7 @@ NSString * const MMshowsSelectionIndicator = @"showsSelectionIndicator";
 
      //_pickerViewToolBar.tintColor = toolbarBackgroundColor;
   
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+    #if __IPHONE_7_0
     _pickerViewToolBar.barTintColor = toolbarBackgroundColor;
     #endif
   }


### PR DESCRIPTION
Fixed toolbar color change problem when deployment target on pods is lower than 7.
http://stackoverflow.com/questions/10349752/iphone-os-version-min-required-does-not-return-deployment-target
